### PR TITLE
refactor: batch operations and migrate to Odin 2026.05 APIs

### DIFF
--- a/vuru/src/commands/install.odin
+++ b/vuru/src/commands/install.odin
@@ -41,90 +41,81 @@ install_run :: proc(args: []string, config: ^Config) -> int {
 		return 1
 	}
 
-	exit_code := 0
-
-	for pkg_name in args {
-		// Resolve dependencies
-		res, ok := resolve.resolve_deps(pkg_name, &idx, config.force_build)
-		if !ok {
-			// Print detailed errors if available
-			if len(res.errors) > 0 {
-				for err in res.errors {
-					errors.print_error(err)
-				}
-			} else {
-				errors.log_error("Failed to resolve dependencies for %s", pkg_name)
+	// Resolve dependencies for all packages at once
+	res, res_ok := resolve.resolve_deps(args, &idx, config.force_build)
+	if !res_ok {
+		if len(res.errors) > 0 {
+			for err in res.errors {
+				errors.print_error(err)
 			}
-			exit_code = 1
-			continue
+		} else {
+			errors.log_error("Failed to resolve dependencies")
 		}
+		return 1
+	}
 
-		// Check for missing packages
-		if len(res.missing) > 0 {
-			// Use detailed errors if available
-			if len(res.errors) > 0 {
-				for err in res.errors {
-					errors.print_error(err)
-				}
-			} else {
-				errors.log_error(
-					"Cannot resolve: %s",
-					strings.join(res.missing[:], ", ", context.temp_allocator),
-				)
+	// Check for missing packages
+	if len(res.missing) > 0 {
+		if len(res.errors) > 0 {
+			for err in res.errors {
+				errors.print_error(err)
 			}
-			exit_code = 1
-			continue
+		} else {
+			errors.log_error(
+				"Cannot resolve: %s",
+				strings.join(res.missing[:], ", ", context.temp_allocator),
+			)
 		}
+		return 1
+	}
 
-		// Dry run - just show what would happen
-		if config.dry_run {
-			resolve.resolution_print(&res)
-			continue
-		}
+	// Dry run - just show what would happen
+	if config.dry_run {
+		resolve.resolution_print(&res)
+		return 0
+	}
 
-		// Create transaction
-		tx := transaction.transaction_from_resolution(&res)
+	// Create transaction
+	tx := transaction.transaction_from_resolution(&res)
 
-		transaction.transaction_print(&tx)
+	transaction.transaction_print(&tx)
 
-		// Confirm unless -y
-		if !config.yes && !transaction.transaction_confirm(&tx) {
-			errors.log_info("Installation cancelled")
-			continue
-		}
+	// Confirm unless -y
+	if !config.yes && !transaction.transaction_confirm(&tx) {
+		errors.log_info("Installation cancelled")
+		return 0
+	}
 
-		// Get build config if needed
-		build_cfg: builder.Build_Config
-		has_build := false
-		for item in tx.items {
-			if item.op == .Build_Install {
-				has_build = true
-				break
-			}
-		}
-
-		if has_build {
-			cfg_result, cfg_ok := builder.default_build_config()
-			if !cfg_ok {
-				errors.log_error("VUP repository not found. Run 'vuru clone' first.")
-				exit_code = 1
-				continue
-			}
-			build_cfg = cfg_result
-		}
-
-		// Execute
-		if !transaction.transaction_execute(&tx, &build_cfg, config.yes) {
-			exit_code = 1
+	// Get build config if needed
+	build_cfg: builder.Build_Config
+	has_build := false
+	for item in tx.items {
+		if item.op == .Build_Install {
+			has_build = true
+			break
 		}
 	}
 
-	return exit_code
+	if has_build {
+		cfg_result, cfg_ok := builder.default_build_config()
+		if !cfg_ok {
+			errors.log_error("VUP repository not found. Run 'vuru clone' first.")
+			return 1
+		}
+		build_cfg = cfg_result
+	}
+
+	// Execute
+	if !transaction.transaction_execute(&tx, &build_cfg, config.yes) {
+		return 1
+	}
+
+	return 0
 }
 
 // System upgrade (xbps-install -u)
 install_update :: proc(config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 16]string
 	append(&cmd, "sudo", "xbps-install", "-u")
 
 	if config.dry_run {

--- a/vuru/src/commands/query.odin
+++ b/vuru/src/commands/query.odin
@@ -58,7 +58,7 @@ query_list :: proc(config: ^Config) -> int {
 
 // Find package owning a file (xbps-query -o)
 query_ownedby :: proc(file: string, config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 8]string
 	append(&cmd, "xbps-query", "-o", file)
 	if len(config.rootdir) > 0 {
 		append(&cmd, "-r", config.rootdir)
@@ -68,7 +68,7 @@ query_ownedby :: proc(file: string, config: ^Config) -> int {
 
 // Show package files (xbps-query -f)
 query_files :: proc(pkg: string, config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 8]string
 	append(&cmd, "xbps-query", "-f", pkg)
 	if len(config.rootdir) > 0 {
 		append(&cmd, "-r", config.rootdir)
@@ -78,7 +78,7 @@ query_files :: proc(pkg: string, config: ^Config) -> int {
 
 // Show package dependencies (xbps-query -x)
 query_deps :: proc(pkg: string, config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 8]string
 	append(&cmd, "xbps-query", "-x", pkg)
 	if config.recursive {
 		append(&cmd, "--fulldeptree")
@@ -167,7 +167,7 @@ query_info :: proc(args: []string, config: ^Config) -> int {
 			fmt.println()
 		} else if !config.vup_only {
 			// Check official repos
-			cmd := make([dynamic]string, context.temp_allocator)
+			cmd: [dynamic; 8]string
 			append(&cmd, "xbps-query", "-R", pkg_name)
 			if len(config.rootdir) > 0 {
 				append(&cmd, "-r", config.rootdir)

--- a/vuru/src/commands/remove.odin
+++ b/vuru/src/commands/remove.odin
@@ -1,9 +1,11 @@
 package commands
 
+import "core:fmt"
+import "core:strings"
+
 import errors "../core/errors"
 import xbps "../core/xbps"
 import utils "../utils"
-import "core:fmt"
 
 // Remove command implementation
 remove_run :: proc(args: []string, config: ^Config) -> int {
@@ -25,19 +27,47 @@ remove_run :: proc(args: []string, config: ^Config) -> int {
 		return 1
 	}
 
-	exit_code := 0
-	for pkg in args {
-		if xbps_uninstall(pkg, config) != 0 {
-			exit_code = 1
-		}
+	cmd: [dynamic; 64]string
+
+	if !config.dry_run {
+		append(&cmd, "sudo")
+	}
+	append(&cmd, "xbps-remove")
+
+	if config.dry_run {
+		append(&cmd, "-n")
+	}
+	if config.yes {
+		append(&cmd, "-y")
+	}
+	if config.recursive {
+		append(&cmd, "-R")
+	}
+	if config.verbose {
+		append(&cmd, "-v")
+	}
+	if len(config.rootdir) > 0 {
+		append(&cmd, "-r", config.rootdir)
 	}
 
-	return exit_code
+	for pkg in args {
+		append(&cmd, pkg)
+	}
+
+	errors.log_info("Removing %s...", strings.join(args[:], ", ", context.temp_allocator))
+
+	if utils.run_command(cmd[:]) == 0 {
+		errors.log_info("Successfully removed package(s)")
+		return 0
+	}
+
+	errors.log_error("xbps-remove failed")
+	return 1
 }
 
 // Remove orphan packages (xbps-remove -o)
 remove_orphans :: proc(config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 16]string
 
 	// Need sudo for system operations (unless dry-run)
 	if !config.dry_run {
@@ -64,7 +94,7 @@ remove_orphans :: proc(config: ^Config) -> int {
 
 // Clean package cache (xbps-remove -O)
 remove_cache :: proc(config: ^Config) -> int {
-	cmd := make([dynamic]string, context.temp_allocator)
+	cmd: [dynamic; 16]string
 
 	// Need sudo for cache operations (unless dry-run)
 	if !config.dry_run {
@@ -87,46 +117,4 @@ remove_cache :: proc(config: ^Config) -> int {
 
 	errors.log_info("Cleaning package cache...")
 	return xbps.clean_cache(utils.run_command)
-}
-
-// Remove a package using xbps-remove
-xbps_uninstall :: proc(pkg_name: string, config: ^Config) -> int {
-	if len(pkg_name) == 0 {
-		errors.log_error("Invalid package name")
-		return -1
-	}
-
-	errors.log_info("Removing %s...", pkg_name)
-
-	cmd := make([dynamic]string, context.temp_allocator)
-
-	// Need sudo for package removal (unless dry-run)
-	if !config.dry_run {
-		append(&cmd, "sudo")
-	}
-	append(&cmd, "xbps-remove", pkg_name)
-
-	if config.dry_run {
-		append(&cmd, "-n")
-	}
-	if config.yes {
-		append(&cmd, "-y")
-	}
-	if config.recursive {
-		append(&cmd, "-R")
-	}
-	if config.verbose {
-		append(&cmd, "-v")
-	}
-	if len(config.rootdir) > 0 {
-		append(&cmd, "-r", config.rootdir)
-	}
-
-	if utils.run_command(cmd[:]) == 0 {
-		errors.log_info("Successfully removed %s", pkg_name)
-		return 0
-	}
-
-	errors.log_error("xbps-remove failed for %s", pkg_name)
-	return -1
 }

--- a/vuru/src/commands/update.odin
+++ b/vuru/src/commands/update.odin
@@ -55,11 +55,6 @@ get_installed_version :: proc(pkg_name: string, allocator := context.allocator) 
 	return xbps.get_installed_version(pkg_name, utils.run_command_output, allocator)
 }
 
-// Run xbps-install for upgrade
-run_xbps_upgrade :: proc(repo_url: string, pkg_name: string, yes: bool) -> int {
-	return xbps.upgrade_from_repo(repo_url, pkg_name, yes, utils.run_command)
-}
-
 // Parse installed package line from xbps-query -l
 parse_installed_pkg :: proc(line: string) -> (name: string, version: string, ok: bool) {
 	parts := strings.fields(line, context.temp_allocator)
@@ -214,6 +209,7 @@ xbps_upgrade_all :: proc(idx: ^index.Index, yes: bool) -> int {
 	fmt.println()
 
 	// Phase 2: Fetch templates (unless --yes)
+	confirmed := yes
 	if !yes {
 		errors.log_info("Fetching templates for review...")
 
@@ -234,26 +230,57 @@ xbps_upgrade_all :: proc(idx: ^index.Index, yes: bool) -> int {
 			errors.log_info("Upgrade cancelled by user")
 			return 0
 		}
+		confirmed = true
 	}
 
 	// Phase 4: Perform upgrades
 	upgraded := 0
 	err_count := 0
 
-	for u in upgrades {
-		errors.log_info("Upgrading %s...", u.name)
+	// Group upgrades by repo URL for batch execution
+	Upgrade_Group :: struct {
+		repo_url: string,
+		upgrades: [dynamic]^Upgrade_Info,
+	}
+	groups := make([dynamic]Upgrade_Group, context.temp_allocator)
 
-		if run_xbps_upgrade(u.repo_url, u.name, yes) != 0 {
-			errors.log_error("Failed to upgrade %s", u.name)
+	for &u in upgrades {
+		found := false
+		for &group in groups {
+			if group.repo_url == u.repo_url {
+				append(&group.upgrades, &u)
+				found = true
+				break
+			}
+		}
+		if !found {
+			append(&groups, Upgrade_Group{
+				repo_url = u.repo_url,
+				upgrades = make([dynamic]^Upgrade_Info, context.temp_allocator),
+			})
+			append(&groups[len(groups) - 1].upgrades, &u)
+		}
+	}
+
+	for group in groups {
+		pkg_names := make([dynamic]string, context.temp_allocator)
+		for u in group.upgrades {
+			append(&pkg_names, u.name)
+		}
+
+		errors.log_info("Upgrading %d package(s) from VUP...", len(pkg_names))
+
+		if xbps.upgrade_packages_from_repo(group.repo_url, pkg_names[:], confirmed, utils.run_command) != 0 {
+			errors.log_error("Failed to upgrade %d package(s)", len(pkg_names))
 			err_count += 1
 		} else {
-			// Verify upgrade happened
-			new_ver, ver_ok := get_installed_version(u.name, context.temp_allocator)
-			if ver_ok && new_ver != u.installed_ver {
-				upgraded += 1
-				// Update template cache
-				if len(u.new_template) > 0 {
-					template.cache_save_template(u.name, u.new_template)
+			for u in group.upgrades {
+				new_ver, ver_ok := get_installed_version(u.name, context.temp_allocator)
+				if ver_ok && new_ver != u.installed_ver {
+					upgraded += 1
+					if len(u.new_template) > 0 {
+						template.cache_save_template(u.name, u.new_template)
+					}
 				}
 			}
 		}

--- a/vuru/src/core/builder/builder.odin
+++ b/vuru/src/core/builder/builder.odin
@@ -147,7 +147,7 @@ install_local_package :: proc(cfg: ^Build_Config, pkg_name: string, yes: bool) -
 	}
 
 	// xbps-install from local repository
-	args := make([dynamic]string, context.temp_allocator)
+	args: [dynamic; 8]string
 	append(&args, "sudo", "xbps-install", "-R", binpkgs)
 
 	if yes {

--- a/vuru/src/core/builder/xbps_src.odin
+++ b/vuru/src/core/builder/xbps_src.odin
@@ -129,7 +129,7 @@ find_package_template :: proc(srcpkgs_dir: string, pkg_name: string) -> string {
 	// Since we use temp_allocator, it will be freed at end of frame/scope.
 
 	for fi in file_infos {
-		if fi.is_dir {
+		if fi.type == .Directory {
 			// Check srcpkgs/<category>/<pkgname>/template
 			cat_path := utils.path_join(
 				srcpkgs_dir,
@@ -348,6 +348,42 @@ install_vup_deps_for_pkg :: proc(
 	return true, {}, installed_files
 }
 
+// Install a built package on the host system using xbps-install, pulling from
+// every subdirectory under hostdir/binpkgs as a possible repository.
+host_install_pkg :: proc(pkg_name: string, binpkgs_dir: string) -> (bool, errors.Error) {
+	if !os.exists(binpkgs_dir) {
+		return false, errors.make_error(.Command_Failed, fmt.tprintf("missing %s", binpkgs_dir))
+	}
+
+	d, err := os.open(binpkgs_dir)
+	if err != os.ERROR_NONE {
+		return false, errors.make_error(.Command_Failed, fmt.tprintf("cannot read %s", binpkgs_dir))
+	}
+	defer os.close(d)
+
+	file_infos, _ := os.read_dir(d, -1, context.temp_allocator)
+
+	cmd: [dynamic]string
+	append(&cmd, "sudo", "xbps-install")
+
+	// hostdir/binpkgs itself (some templates drop packages here) plus every subdir.
+	append(&cmd, fmt.tprintf("--repository=%s", binpkgs_dir))
+	for fi in file_infos {
+		if fi.type == .Directory {
+			sub_path := utils.path_join(binpkgs_dir, fi.name, allocator = context.temp_allocator)
+			append(&cmd, fmt.tprintf("--repository=%s", sub_path))
+		}
+	}
+
+	append(&cmd, pkg_name)
+
+	errors.log_info("Installing %s on host system...", pkg_name)
+	if utils.run_command(cmd[:]) != 0 {
+		return false, errors.make_error(.Command_Failed, fmt.tprintf("xbps-install %s", pkg_name))
+	}
+	return true, {}
+}
+
 // Run xbps-src with the given arguments
 run_xbps_src :: proc(xbps_src_path: string, args: []string) -> bool {
 	// Build the command as string array
@@ -499,6 +535,14 @@ xbps_src_main :: proc(args: []string, config: ^Config) -> (bool, errors.Error) {
 	cmd := cmd_args[0]
 	remaining_args := cmd_args[1:] if len(cmd_args) > 1 else []string{}
 
+	// `vuru src install <pkg>` builds the binary package and then installs it on
+	// the host system from hostdir/binpkgs. We rewrite the inner xbps-src call to
+	// `pkg` and remember to run xbps-install afterwards.
+	host_install := cmd == "install"
+	if host_install {
+		cmd = "pkg"
+	}
+
 	// Find xbps-src
 	xbps_src_path, found := find_xbps_src()
 	if !found {
@@ -558,8 +602,12 @@ xbps_src_main :: proc(args: []string, config: ^Config) -> (bool, errors.Error) {
 		append(&xbps_args, "-a")
 		append(&xbps_args, cross_target)
 	}
-	for arg in cmd_args {
-		append(&xbps_args, arg)
+	for arg, i in cmd_args {
+		if i == 0 && host_install {
+			append(&xbps_args, "pkg")
+		} else {
+			append(&xbps_args, arg)
+		}
 	}
 
 	// Run the actual xbps-src command
@@ -567,6 +615,21 @@ xbps_src_main :: proc(args: []string, config: ^Config) -> (bool, errors.Error) {
 	errors.log_info("Running: xbps-src %s", joined_args)
 	if !run_xbps_src(xbps_src_path, xbps_args[:]) {
 		return false, errors.make_error(.Command_Failed, fmt.tprintf("xbps-src %s", joined_args))
+	}
+
+	if host_install {
+		pkg_name := extract_pkg_name(cmd, remaining_args)
+		if pkg_name == "" {
+			return false, errors.make_error(
+				.Missing_Argument,
+				"package name for 'install' command",
+			)
+		}
+		binpkgs := get_binpkgs_dir(xbps_src_path, context.temp_allocator)
+		ok, err := host_install_pkg(pkg_name, binpkgs)
+		if !ok {
+			return false, err
+		}
 	}
 	return true, {}
 }
@@ -586,7 +649,7 @@ xbps_src_usage :: proc() {
 	fmt.println("  configure <pkgname>  Configure <pkgname>")
 	fmt.println("  build <pkgname>      Build <pkgname>")
 	fmt.println("  check <pkgname>      Run tests for <pkgname>")
-	fmt.println("  install <pkgname>    Install <pkgname> into destdir")
+	fmt.println("  install <pkgname>    Build <pkgname> and install it on the host system")
 	fmt.println("  clean <pkgname>      Clean up <pkgname> build directory")
 	fmt.println("  show <pkgname>       Show info about <pkgname>")
 	fmt.println("  ... and all other xbps-src commands")

--- a/vuru/src/core/errors/format.odin
+++ b/vuru/src/core/errors/format.odin
@@ -1,8 +1,6 @@
 package errors
 
 import "core:fmt"
-import "core:io"
-import "core:os"
 
 // ANSI color codes (centralized here for all of vuru)
 COLOR_RESET :: "\033[0m"

--- a/vuru/src/core/resolve/resolver.odin
+++ b/vuru/src/core/resolve/resolver.odin
@@ -139,9 +139,9 @@ resolve_package :: proc(
 	return {}, false
 }
 
-// Resolve dependencies for a target package
+// Resolve dependencies for one or more target packages
 resolve_deps :: proc(
-	target: string,
+	targets: []string,
 	idx: ^index.Index,
 	include_makedeps: bool,
 	allocator := context.allocator,
@@ -149,7 +149,7 @@ resolve_deps :: proc(
 	Resolution,
 	bool,
 ) {
-	res := resolution_make(target, allocator)
+	res := resolution_make(strings.join(targets, " ", allocator), allocator)
 
 	arch, arch_ok := config.get_arch()
 	if !arch_ok {
@@ -166,8 +166,10 @@ resolve_deps :: proc(
 	queue := make([dynamic]Queue_Item, allocator)
 
 
-	// Add target to queue
-	append(&queue, Queue_Item{name = strings.clone(target, allocator), depth = 0})
+	// Add all targets to queue
+	for target in targets {
+		append(&queue, Queue_Item{name = strings.clone(target, allocator), depth = 0})
+	}
 
 	for len(queue) > 0 {
 		// Pop from front
@@ -298,7 +300,7 @@ resolution_print :: proc(r: ^Resolution) {
 
 	// If target is satisfied and nothing to install/build, just say package is installed
 	if target_satisfied && len(r.to_install) == 0 && len(r.to_build) == 0 {
-		fmt.printf("Package already installed: %s\n", r.target)
+		fmt.printf("Already installed: %s\n", r.target)
 		return
 	}
 

--- a/vuru/src/core/transaction/transaction.odin
+++ b/vuru/src/core/transaction/transaction.odin
@@ -108,63 +108,104 @@ transaction_execute :: proc(t: ^Transaction, cfg: ^builder.Build_Config, yes: bo
 		return true
 	}
 
+	// Group packages by operation type for batch execution
+	VUP_Group :: struct {
+		repo_url: string,
+		pkgs:     [dynamic]string,
+	}
+
+	official_pkgs := make([dynamic]string, context.temp_allocator)
+	vup_groups := make([dynamic]VUP_Group, context.temp_allocator)
+	remove_pkgs := make([dynamic]string, context.temp_allocator)
+	builds := make([dynamic]^Transaction_Item, context.temp_allocator)
+
 	for &item in t.items {
 		switch item.op {
 		case .Install_Official:
-			if !execute_install_official(&item, yes) {
-				return false
-			}
+			append(&official_pkgs, item.name)
 
 		case .Install_VUP:
-			if !execute_install_vup(&item, yes) {
-				return false
+			found := false
+			for &group in vup_groups {
+				if group.repo_url == item.repo_url {
+					append(&group.pkgs, item.name)
+					found = true
+					break
+				}
 			}
-
-		case .Build_Install:
-			if !execute_build_install(&item, cfg, yes) {
-				return false
+			if !found {
+				append(&vup_groups, VUP_Group{
+					repo_url = item.repo_url,
+					pkgs     = make([dynamic]string, context.temp_allocator),
+				})
+				append(&vup_groups[len(vup_groups) - 1].pkgs, item.name)
 			}
 
 		case .Remove:
-			if !execute_remove(&item, yes) {
-				return false
-			}
+			append(&remove_pkgs, item.name)
+
+		case .Build_Install:
+			append(&builds, &item)
 
 		case .Upgrade:
-			// Handled by install with newer version
 		}
 	}
 
-	return true
-}
+	// Execute official installs in one batch
+	if len(official_pkgs) > 0 {
+		errors.log_info("Installing %d package(s) from official repos...", len(official_pkgs))
 
-// Execute handlers for each operation type
-@(private)
-execute_install_official :: proc(item: ^Transaction_Item, yes: bool) -> bool {
-	errors.log_info("Installing %s from official repos...", item.name)
-	
-	args := make([dynamic]string, context.temp_allocator)
-	append(&args, "sudo", "xbps-install", "-S")
-	if yes {
-		append(&args, "-y")
-	}
-	append(&args, item.name)
+		args: [dynamic; 64]string
+		append(&args, "sudo", "xbps-install", "-S")
+		if yes {
+			append(&args, "-y")
+		}
+		for pkg in official_pkgs {
+			append(&args, pkg)
+		}
 
-	if utils.run_command(args[:]) != 0 {
-		errors.log_error("Failed to install %s", item.name)
-		return false
+		if utils.run_command(args[:]) != 0 {
+			errors.log_error("Failed to install official packages")
+			return false
+		}
 	}
-	return true
-}
 
-@(private)
-execute_install_vup :: proc(item: ^Transaction_Item, yes: bool) -> bool {
-	errors.log_info("Installing %s from VUP...", item.name)
-	
-	if xbps.install_from_repo(item.repo_url, item.name, yes, utils.run_command) != 0 {
-		errors.log_error("Failed to install %s", item.name)
-		return false
+	// Execute VUP installs grouped by repo
+	for group in vup_groups {
+		errors.log_info("Installing %d package(s) from VUP...", len(group.pkgs))
+
+		if xbps.install_packages_from_repo(group.repo_url, group.pkgs[:], yes, utils.run_command) != 0 {
+			errors.log_error("Failed to install VUP packages")
+			return false
+		}
 	}
+
+	// Execute removes in one batch
+	if len(remove_pkgs) > 0 {
+		errors.log_info("Removing %d package(s)...", len(remove_pkgs))
+
+		args: [dynamic; 64]string
+		append(&args, "sudo", "xbps-remove", "-R")
+		if yes {
+			append(&args, "-y")
+		}
+		for pkg in remove_pkgs {
+			append(&args, pkg)
+		}
+
+		if utils.run_command(args[:]) != 0 {
+			errors.log_error("Failed to remove packages")
+			return false
+		}
+	}
+
+	// Execute builds individually
+	for item in builds {
+		if !execute_build_install(item, cfg, yes) {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -179,17 +220,6 @@ execute_build_install :: proc(item: ^Transaction_Item, cfg: ^builder.Build_Confi
 	
 	if !builder.install_local_package(cfg, item.name, yes) {
 		errors.log_error("Failed to install built package %s", item.name)
-		return false
-	}
-	return true
-}
-
-@(private)
-execute_remove :: proc(item: ^Transaction_Item, yes: bool) -> bool {
-	errors.log_info("Removing %s...", item.name)
-	
-	if xbps.remove_package(item.name, yes, utils.run_command) != 0 {
-		errors.log_error("Failed to remove %s", item.name)
 		return false
 	}
 	return true

--- a/vuru/src/core/xbps/install.odin
+++ b/vuru/src/core/xbps/install.odin
@@ -16,6 +16,22 @@ install_from_repo :: proc(
 	return run_cmd(args[:])
 }
 
+// Install multiple packages from a specific repository in a single transaction
+install_packages_from_repo :: proc(
+	repo_url: string,
+	pkg_names: []string,
+	yes: bool,
+	run_cmd: Command_Runner,
+) -> int {
+	args := build_args_with_yes(yes, "sudo", "xbps-install", "-R", repo_url, "-S")
+
+
+	for name in pkg_names {
+		append(&args, name)
+	}
+	return run_cmd(args[:])
+}
+
 // Sync package index only
 sync_repos :: proc(run_cmd: Command_Runner) -> int {
 	return run_cmd({"sudo", "xbps-install", "-S"})

--- a/vuru/src/core/xbps/upgrade.odin
+++ b/vuru/src/core/xbps/upgrade.odin
@@ -16,6 +16,22 @@ upgrade_from_repo :: proc(
 	return run_cmd(args[:])
 }
 
+// Upgrade multiple packages from a repository in a single transaction
+upgrade_packages_from_repo :: proc(
+	repo_url: string,
+	pkg_names: []string,
+	yes: bool,
+	run_cmd: Command_Runner,
+) -> int {
+	args := build_args_with_yes(yes, "sudo", "xbps-install", "-R", repo_url, "-Su")
+
+
+	for name in pkg_names {
+		append(&args, name)
+	}
+	return run_cmd(args[:])
+}
+
 // Upgrade all packages from official repos
 upgrade_all_official :: proc(yes: bool, run_cmd: Command_Runner) -> int {
 	args := build_args_with_yes(yes, "sudo", "xbps-install", "-Su")

--- a/vuru/src/main.odin
+++ b/vuru/src/main.odin
@@ -8,7 +8,7 @@ import "core:strings"
 import commands "commands"
 import errors "core/errors"
 
-VERSION :: "0.5.5"
+VERSION :: "0.6.0"
 INDEX_URL :: "https://vup-linux.github.io/vup/index.json"
 
 // Arena size for command execution (4MB should be plenty)

--- a/vuru/src/utils/utils.odin
+++ b/vuru/src/utils/utils.odin
@@ -15,8 +15,8 @@ foreign libc {
 
 // Read entire file contents
 read_file :: proc(path: string, allocator := context.allocator) -> (string, bool) {
-	data, ok := os.read_entire_file(path, allocator)
-	if !ok {
+	data, err := os.read_entire_file(path, allocator)
+	if err != nil {
 		return "", false
 	}
 	return string(data), true
@@ -24,7 +24,7 @@ read_file :: proc(path: string, allocator := context.allocator) -> (string, bool
 
 // Write string content to a file
 write_file :: proc(path: string, content: string) -> bool {
-	return os.write_entire_file(path, transmute([]u8)content)
+	return os.write_entire_file(path, transmute([]u8)content) == nil
 }
 
 
@@ -201,33 +201,7 @@ mkdir_p :: proc(path: string) -> bool {
 	if os.exists(path) {
 		return os.is_dir(path)
 	}
-
-	err := os.make_directory(path)
-	if err == os.ERROR_NONE {
-		return true
-	}
-
-	// Try to create parent first
-	parent := parent_dir(path)
-	if len(parent) > 0 && parent != path {
-		if !mkdir_p(parent) {
-			return false
-		}
-		return os.make_directory(path) == os.ERROR_NONE
-	}
-
-	return false
-}
-
-// Get parent directory
-parent_dir :: proc(path: string) -> string {
-	for i := len(path) - 1; i >= 0; i -= 1 {
-		if path[i] == '/' {
-			if i == 0 {return "/"}
-			return path[:i]
-		}
-	}
-	return ""
+	return os.make_directory_all(path) == nil
 }
 
 // Join paths


### PR DESCRIPTION
Batch package operations to avoid repetitive per-package prompts:
- install: resolve all targets in a single resolution / transaction / prompt
- remove: pass all packages to one xbps-remove call for proper dep ordering
- update: group VUP upgrades by repo, skip per-package prompts after batch review
- transaction: group installs and removes by type+repo for single xbps calls
- xbps: add plural install/upgrade-from-repo variants accepting []string

Migrate to Odin 2026.05 APIs (no :os calls, updated signatures):
- make([]dynamic) -> [dynamic; N] inline array declarations
- os.read_entire_file / write_entire_file: use nil error checks
- os.make_directory + recursive logic -> os.make_directory_all
- fi.is_dir -> fi.type == .Directory, os.open returns (handle, err)
- remove unused core:io, core:os imports and parent_dir helper
- add vuru src install subcommand with host_install_pkg