### PR TITLE
feat: add fcitx5-lotus 3.5.3

### DIFF
--- a/vup/srcpkgs/utilities/fcitx5-lotus-settings
+++ b/vup/srcpkgs/utilities/fcitx5-lotus-settings
@@ -1,0 +1,1 @@
+fcitx5-lotus

--- a/vup/srcpkgs/utilities/fcitx5-lotus/template
+++ b/vup/srcpkgs/utilities/fcitx5-lotus/template
@@ -1,0 +1,49 @@
+# Template file for 'fcitx5-lotus'
+pkgname=fcitx5-lotus
+version=3.5.3
+revision=1
+_bamboo_commit="9197d2cc164380a80d219f12cc90576ff2fbf5e6"
+build_style=cmake
+configure_args="-DLOTUS_UINPUT_PROXY_USER=_uinput_proxy -DINSTALL_RUNIT=ON -DRUNIT_SV_DIR=/usr/share/examples/sv"
+hostmakedepends="extra-cmake-modules pkg-config gettext go python3 librsvg-utils"
+makedepends="libfcitx5-devel libinput-devel eudev-libudev-devel acl-devel libX11-devel"
+depends="fcitx5 acl acl-progs"
+short_desc="Vietnamese input method for fcitx5"
+maintainer="Leanhduc <0353618151hao@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/LotusInputMethod/fcitx5-lotus"
+distfiles="https://github.com/LotusInputMethod/fcitx5-lotus/archive/refs/tags/v${version}.tar.gz>fcitx5-lotus-${version}.tar.gz
+ https://github.com/LotusInputMethod/bamboo-core/archive/${_bamboo_commit}.tar.gz>bamboo-core-${_bamboo_commit}.tar.gz"
+checksum="2c38ebbaa70a5e4595f71a07226c0f450868eb181dc6f2710248236238ae7f90 aa446dcebcda95feb384bf3caa98418dd553d54f138f25cad716472c387a1d90"
+skip_extraction="bamboo-core-${_bamboo_commit}.tar.gz"
+
+system_accounts="_uinput_proxy"
+_uinput_proxy_groups="input"
+
+post_extract() {
+	mkdir -p bamboo/bamboo-core
+	vsrcextract -C bamboo/bamboo-core "bamboo-core-${_bamboo_commit}.tar.gz"
+}
+
+pre_build() {
+	export CGO_ENABLED=1
+	if [ "$CROSS_BUILD" ]; then
+		case "$XBPS_TARGET_MACHINE" in
+			aarch64*) export GOARCH=arm64 ;;
+			armv6l*)  export GOARCH=arm; export GOARM=6 ;;
+			armv7l*)  export GOARCH=arm; export GOARM=7 ;;
+			i686*)    export GOARCH=386 ;;
+			x86_64*)  export GOARCH=amd64 ;;
+		esac
+	fi
+}
+
+fcitx5-lotus-settings_package() {
+	short_desc+=" - GUI settings"
+	depends="python3 python3-QtPy python3-pyqt6 python3-dbus python3-pyqt6-widgets python3-pyqt6-gui qt6-wayland"
+	pkg_install() {
+		vmove usr/bin/fcitx5-lotus-settings
+		vmove usr/share/fcitx5-lotus/settings-gui
+		vmove usr/share/applications/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop
+	}
+}


### PR DESCRIPTION
Add `fcitx5-lotus` package and its subpackage `fcitx5-lotus-settings`.

- **Category:** `utilities`
- **Package:** `fcitx5-lotus` (v3.5.3)
- **Subpackage:** `fcitx5-lotus-settings`
- **Description:** Vietnamese input method for fcitx5